### PR TITLE
Update Lecture3.ipynb - Fix typo

### DIFF
--- a/Lecture3/Lecture3.ipynb
+++ b/Lecture3/Lecture3.ipynb
@@ -748,7 +748,7 @@
    "source": [
     "### ~~Backward~~ Reverse Differentiation\n",
     "\n",
-    "Viewing this as a product of Jacobian matrices, linear algebra will allow us to find a faster way to compute the gradient. This is will introduce *reverse differentiation*.\n",
+    "Viewing this as a product of Jacobian matrices, linear algebra will allow us to find a faster way to compute the gradient. This will introduce *reverse differentiation*.\n",
     "\n",
     "The broadcasted `*` is an Hadamard product, denoted $\\odot$. So what we compute in `jacobian_combine` is:\n",
     "$$\n",


### PR DESCRIPTION
Fix typo in Reverse Differentiation section: one extra verb "is"
Lison Van Asbrouck - 25192000