### PR TITLE
In 2_diffusion.jl - VAEs section contains a small typo

### DIFF
--- a/Lectures/2_diffusion.jl
+++ b/Lectures/2_diffusion.jl
@@ -266,7 +266,7 @@ frametitle("Variational AutoEncoders (VAEs)")
 # ╔═╡ 23f3de75-0617-4232-bb71-bd9f3e355a1e
 md"""
 * We want to learn the distribution of our data represented by the random variable ``X``.
-* The encoder maps a data point ``x`` to a Gaussian distribution ``Y \sim \mathcal{N}(E_\mu(x), E_{\Sigma}(x)))`` over the latent space
+* The encoder maps a data point ``x`` to a Gaussian distribution ``Y \sim \mathcal{N}(E_\mu(x), E_{\Sigma}(x))`` over the latent space
 * The decoder maps a latent variable ``z \sim Z`` to a data point ``D(z)``
 
 The Maximum Likelyhood Estimator (MLE) maximizes the following sum over our datapoints ``x`` with its ELBO:


### PR DESCRIPTION
Hello,

In the section talking about Variational AutoEncoders (VAEs), in the second bullet point explaining that the encoder maps a data point x to a Gaussian Distribution, the definition of Y contains an extra ")" at the end that is never opened. This PR just removes it.

Here is my full name and my NOMA: 
Victor Rijks, 51262000

Thanks !