### PR TITLE
In 2_diffusion.jl - 3 instances of extra ]

### DIFF
--- a/Lectures/2_diffusion.jl
+++ b/Lectures/2_diffusion.jl
@@ -266,7 +266,7 @@ frametitle("Variational AutoEncoders (VAEs)")
 # ╔═╡ 23f3de75-0617-4232-bb71-bd9f3e355a1e
 md"""
 * We want to learn the distribution of our data represented by the random variable ``X``.
-* The encoder maps a data point ``x`` to a Gaussian distribution ``Y \sim \mathcal{N}(E_\mu(x), E_{\Sigma}(x)))`` over the latent space
+* The encoder maps a data point ``x`` to a Gaussian distribution ``Y \sim \mathcal{N}(E_\mu(x), E_{\Sigma}(x))`` over the latent space
 * The decoder maps a latent variable ``z \sim Z`` to a data point ``D(z)``
 
 The Maximum Likelyhood Estimator (MLE) maximizes the following sum over our datapoints ``x`` with its ELBO:

--- a/Lectures/2_diffusion.jl
+++ b/Lectures/2_diffusion.jl
@@ -271,11 +271,11 @@ md"""
 
 The Maximum Likelyhood Estimator (MLE) maximizes the following sum over our datapoints ``x`` with its ELBO:
 ```math
-\sum_x \log(f_X(x)) \ge \sum_x -D((Y|X = x) \parallel Z) + \mathbb{E}[\log(f_{X|Z}(x|Y))]]
+\sum_x \log(f_X(x)) \ge \sum_x -D((Y|X = x) \parallel Z) + \mathbb{E}[\log(f_{X|Z}(x|Y))]
 ```
 So the MLE minimizes the loss
 ```math
--\mathbb{E}[\log(f_{X|Z}(x|Y))]]
+-\mathbb{E}[\log(f_{X|Z}(x|Y))]
 ```
 with the KL-regularizer
 ```math
@@ -401,7 +401,7 @@ md"""
 ```
 Evidence Lower-Bound with ``Y = X + \sigma \mathcal{E}`` and ``Z`` such that ``X = D(E(Z))`` $(cite("ho2020Denoising")):
 ```math
--\log(f_X(x)) \le \mathbb{E}[-\log(f_{X|Z}(x|Y))]] + D((Y|X = x) \parallel Z)
+-\log(f_X(x)) \le \mathbb{E}[-\log(f_{X|Z}(x|Y))] + D((Y|X = x) \parallel Z)
 ```
 """
 


### PR DESCRIPTION
Hello (again),

In the sections "Variational AutoEncoders (VAEs)" and "Denoising Auto-Encoder", the expression "-\mathbb{E}[\log(f_{X|Z}(x|Y))]]" appears three times with an extra ] at the end. This PR just removes them.

Here is my full name and my NOMA:
Victor Rijks, 51262000

Sorry for making a second PR, I did not notice those typos before,
Thanks !