### PR TITLE
Fix typos and clarify mathematical notation

### DIFF
--- a/Lectures/diffusion.jl
+++ b/Lectures/diffusion.jl
@@ -253,7 +253,7 @@ frametitle("Evidence Lower BOund (ELBO)")
 # ╔═╡ 8e39960f-ab0a-4103-bd6b-00e779333b01
 qa(md"Proof",
 md"""
-> Reminder: ``D_\text{KL}(A \parallel B) = \sum_{a \in \text{Dom}(A)} f_A(a) \log \frac{f_A(a)}{f_B(a)} = \mathbb{E}_A[\log f_A(A) - \log f_B(A)]``
+> Reminder: ``D_\text{KL}(A \parallel B) = \sum_{a \in \text{Dom}(A)} f_A(a) \log \frac{f_A(a)}{f_B(a)} = \mathbb{E}[\log f_A(A) - \log f_B(A)]``
 
 ```math
 \begin{align}

--- a/Lectures/diffusion.jl
+++ b/Lectures/diffusion.jl
@@ -253,21 +253,21 @@ frametitle("Evidence Lower BOund (ELBO)")
 # ╔═╡ 8e39960f-ab0a-4103-bd6b-00e779333b01
 qa(md"Proof",
 md"""
-> Reminder: ``D_\text{KL}(A \parallel B) = \sum_{a \in \text{Dom}(A)} f_A(a) \log \frac{f_A(a)}{f_B(a)} = \mathbb{E}[\log f_A(A) - \log f_B(A)]``
+> Reminder: ``D_\text{KL}(A \parallel B) = \sum_{a \in \text{Dom}(A)} f_A(a) \log \frac{f_A(a)}{f_B(a)} = \mathbb{E}_A[\log f_A(A) - \log f_B(A)]``
 
 ```math
 \begin{align}
   D_\text{KL}((Y|X = x) \parallel (Z | X = x))
   & =
-  \mathbb{E}[\log(f_{Y|X}(Y|x)) - \log(f_{Z|X}(Y|x))]\\
+  \mathbb{E}_{Y|X}[\log(f_{Y|X}(Y|x)) - \log(f_{Z|X}(Y|x))]\\
   & =
-  \mathbb{E}[\log(f_{Y|X}(Y|x)) - \log(f_{Z,X}(Y,x))]\\
+  \mathbb{E}_{Y|X}[\log(f_{Y|X}(Y|x)) - \log(f_{Z,X}(Y,x))]\\
   & \qquad + \log(f_{X}(x))\\
   & =
-  \mathbb{E}[\log(f_{Y|X}(Y|x)) - \log(f_{X|Z}(x|Y)) - \log(f_{Z}(Y))]\\
+  \mathbb{E}_{Y|X}[\log(f_{Y|X}(Y|x)) - \log(f_{X|Z}(x|Y)) - \log(f_{Z}(Y))]\\
   & \qquad + \log(f_{X}(x))\\
   & =
-  D_\text{KL}((Y|X = x) \parallel Z) - \mathbb{E}[\log(f_{X|Z}(x|Y))]\\
+  D_\text{KL}((Y|X = x) \parallel Z) - \mathbb{E}_{Y|X}[\log(f_{X|Z}(x|Y))]\\
   & \qquad + \log(f_{X}(x))
 \end{align}
 ```
@@ -410,7 +410,7 @@ For any random variables ``X``, ``Y`` and ``Z``, we have
 ```
 where the *evidence lower bound* $(cite("kingma2013AutoEncoding"))
 ```math
-\mathcal{L}(x) = -D_\text{KL}((Y|X = x) \parallel Z) + \mathbb{E}[\log(f_{X|Z}(x|Y))]]
+\mathcal{L}(x) = -D_\text{KL}((Y|X = x) \parallel Z) + \mathbb{E}_{Y|X}[\log(f_{X|Z}(x|Y))]]
 ```
 """
 

--- a/Lectures/diffusion.jl
+++ b/Lectures/diffusion.jl
@@ -267,7 +267,7 @@ md"""
   \mathbb{E}[\log(f_{Y|X}(Y|x)) - \log(f_{X|Z}(x|Y)) - \log(f_{Z}(Y)) | X = x]\\
   & \qquad + \log(f_{X}(x))\\
   & =
-  D_\text{KL}((Y|X = x) \parallel Z) - \mathbb{E}_{Y|X}[\log(f_{X|Z}(x|Y)) | X = x]\\
+  D_\text{KL}((Y|X = x) \parallel Z) - \mathbb{E}[\log(f_{X|Z}(x|Y)) | X = x]\\
   & \qquad + \log(f_{X}(x))
 \end{align}
 ```

--- a/Lectures/diffusion.jl
+++ b/Lectures/diffusion.jl
@@ -185,7 +185,7 @@ As ``W_t`` and ``\mathcal{E}_\theta(x_t, \sigma_t)`` are independent, their cova
 ```math
 \sigma_{t-1}^2 = \sigma_{t'}^2 \text{Var}(\mathcal{E}_\theta(x_t, \sigma_t)) + \eta^2 \text{Var}(W_t)
 ```
-Their variance is one so we have
+Their variance is one, so we have
 ```math
 \sigma_{t-1}^2 = \sigma_{t'}^2 + \eta^2
 ```
@@ -204,7 +204,7 @@ Find encoder ``E`` and decoder ``D`` that minimize the loss:
 ```math
 \mathbb{E}[\|X - D(E(X))\|_2^2]
 ```
-The *code* (aka *latent variable*) ``z = E(x)`` typically has smaller size compared to ``x`` to force the model to only keep essential features.
+The *code* (aka *latent variable*) ``z = E(x)`` typically has a smaller size compared to ``x`` to force the model to only keep essential features.
 """
 
 # ╔═╡ 40f21927-1d88-41f4-b55d-6b81ca2ec211
@@ -244,7 +244,7 @@ An insightful way to model this is as follows.
 * Assume our dataset come from a distribution ``X`` that is obtained from a latent space ``Z`` using a decoder ``X = D(Z)``.
 * If we knew the latent variable ``z``, we would search for a decoder ``D`` that maximizes ``\mathbb{E}[\log(f_{X|Z}(x|z))]``.
 * Since we do not know ``z``, we make an estimate of ``y`` using an encoder ``Y = E(X)``.
-* The validity of these encoder and decoder models can now be measure with a Maximum Likelihood Estimator that search for the encoder and decoder models that maximizes ``\mathbb{E}[\log(f_X(X))]``.
+* The validity of these encoder and decoder models can now be measured with a Maximum Likelihood Estimator that searches for the encoder and decoder models that maximize ``\mathbb{E}[\log(f_X(X))]``.
 """
 
 # ╔═╡ 6d63c708-6f10-4a21-b57b-a9bd138b5c8c
@@ -259,15 +259,15 @@ md"""
 \begin{align}
   D_\text{KL}((Y|X = x) \parallel (Z | X = x))
   & =
-  \mathbb{E}_{Y|X}[\log(f_{Y|X}(Y|x)) - \log(f_{Z|X}(Y|x))]\\
+  \mathbb{E}[\log(f_{Y|X}(Y|x)) - \log(f_{Z|X}(Y|x)) | X = x]\\
   & =
-  \mathbb{E}_{Y|X}[\log(f_{Y|X}(Y|x)) - \log(f_{Z,X}(Y,x))]\\
+  \mathbb{E}[\log(f_{Y|X}(Y|x)) - \log(f_{Z,X}(Y,x)) | X = x]\\
   & \qquad + \log(f_{X}(x))\\
   & =
-  \mathbb{E}_{Y|X}[\log(f_{Y|X}(Y|x)) - \log(f_{X|Z}(x|Y)) - \log(f_{Z}(Y))]\\
+  \mathbb{E}[\log(f_{Y|X}(Y|x)) - \log(f_{X|Z}(x|Y)) - \log(f_{Z}(Y)) | X = x]\\
   & \qquad + \log(f_{X}(x))\\
   & =
-  D_\text{KL}((Y|X = x) \parallel Z) - \mathbb{E}_{Y|X}[\log(f_{X|Z}(x|Y))]\\
+  D_\text{KL}((Y|X = x) \parallel Z) - \mathbb{E}_{Y|X}[\log(f_{X|Z}(x|Y)) | X = x]\\
   & \qquad + \log(f_{X}(x))
 \end{align}
 ```
@@ -278,7 +278,7 @@ md"""
 md"""
 ``\mathcal{L}(x)`` is a **lower bound** to ``\log(f_X(x))`` as the Kullback-Leibler divergence ``D_\text{KL}((Y|X = x) \parallel (Z | X = x))`` is always nonnegative.
 
-In the context of VAEs, ``Z`` represents the actual latent variable and ``Y`` represents the estimated random variables so ``D_\text{KL}((Y|X = x) \parallel (Z | X = x))`` is a measure of the error made by our estimator.
+In the context of VAEs, ``Z`` represents the actual latent variable and ``Y`` represents the estimated random variables, so ``D_\text{KL}((Y|X = x) \parallel (Z | X = x))`` is a measure of the error made by our estimator.
 """
 
 # ╔═╡ 0788ac02-dab8-4ddd-9130-2a632d8d3685
@@ -311,7 +311,7 @@ md"""
 * The encoder maps a data point ``x`` to a Gaussian distribution ``Y \sim \mathcal{N}(E_\mu(x), E_{\Sigma}(x))`` over the latent space
 * The decoder maps a latent variable ``z \sim Z`` to a the Gaussian distribution ``\mathcal{N}(D_\mu(z), D_\sigma(Z))``
 
-The Maximum Likelyhood Estimator (MLE) maximizes the following sum over our datapoints ``x`` with its ELBO:
+The Maximum Likelihood Estimator (MLE) maximizes the following sum over our datapoints ``x`` with its ELBO:
 ```math
 \sum_x \log(f_X(x)) \ge \sum_x -D_\text{KL}((Y|X = x) \parallel Z) + \mathbb{E}[\log(f_{X|Z}(x|Y))]
 ```
@@ -390,7 +390,7 @@ md"""
 As ``\epsilon_\theta(x_t, \sigma_t)`` is more accurate than
 ``\epsilon_\theta(x_{t+1}, \sigma_{t+1})``,
 $(cite("permenter2024Interpretinga", "Section 5"))
-suggests to accelerate the convergence by correcting part of
+suggests accelerating the convergence by correcting part of
 the previous step. That is, we take:
 ```math
 \bar{\epsilon}_t = \textcolor{purple}{\gamma} \epsilon_\theta(x_t, \sigma_t) \textcolor{purple}{+ (1 - \gamma) \epsilon_\theta(x_{t+1}, \sigma_{t+1})}
@@ -410,7 +410,7 @@ For any random variables ``X``, ``Y`` and ``Z``, we have
 ```
 where the *evidence lower bound* $(cite("kingma2013AutoEncoding"))
 ```math
-\mathcal{L}(x) = -D_\text{KL}((Y|X = x) \parallel Z) + \mathbb{E}_{Y|X}[\log(f_{X|Z}(x|Y))]]
+\mathcal{L}(x) = -D_\text{KL}((Y|X = x) \parallel Z) + \mathbb{E}[\log(f_{X|Z}(x|Y)) | X = x]
 ```
 """
 
@@ -453,14 +453,14 @@ To train the denoising Auto-Encoder, we can use the Evidence Lower-Bound with ``
 """
 
 # ╔═╡ e0ba3b61-a618-49ce-9466-e6a8f674bd53
-md"""Source : $(cite("rombach2022HighResolution", "Figure 3"))"""
+md"""Source: $(cite("rombach2022HighResolution", "Figure 3"))"""
 
 # ╔═╡ 410eac96-a384-48fa-b3f3-478be5bd236c
 md"""
-Improvement for conditioned diffusion for multi-modal distributions : use classifier $(cite("dhariwal2024Diffusion")). **Issue**: need to train a classifier...
+Improvement for conditioned diffusion for multi-modal distributions: use classifier $(cite("dhariwal2024Diffusion")). **Issue**: need to train a classifier...
 
 This classifier-guided strategy was replaced in $(cite("ho2022ClassifierFree"))
-by a simpler trick: Train both a conditioned (with condition ``\tau``) and unconditioned diffusion model and combine then with:
+by a simpler trick: Train both a conditioned (with condition ``\tau``) and an unconditioned diffusion model, and combine them with:
 ```math
 \bar{\epsilon}_t = \textcolor{purple}{\lambda} \epsilon_\theta(x_t, \sigma_t, \tau) \textcolor{purple}{+ (1 - \lambda) \epsilon_\theta(x_t, \sigma_t)} \qquad \text{with } \lambda > 1
 ```

--- a/Lectures/implicit.jl
+++ b/Lectures/implicit.jl
@@ -92,7 +92,7 @@ Assume
 * ``(w_0, \lambda_0)`` such that ``F(w_0, \lambda_0) = 0`` and $(ift_inv.content[].content)
 * ``F(w, \lambda)`` is ``C^2`` in a neighborhood ``\mathcal{U}`` of ``(w_0, \lambda_0)``
 
-Then there exists a neighborhood ``\mathcal{V} \subseteq \mathcal{U}`` there exists ``w^\star(\lambda)`` such that
+Then there exists a neighborhood ``\mathcal{V} \subseteq \mathcal{U}`` where exists ``w^\star(\lambda)`` such that
 $ift_eq
 """
 end;
@@ -426,8 +426,8 @@ Define ``f(\lambda, w) = (\lambda, F(w, \lambda))``. The Jacobian is
 ```
 By assumption, ``\partial_1 F(w, \lambda)`` is invertible so ``\det(\partial f(\lambda, w)) = \det(I)\det(\partial_1 F(w, \lambda)) \neq 0``.
 By the inverse function theorem, the inverse of ``f`` around ``f(\lambda_0, w_0) = (\lambda_0, 0)`` is ``C^2``.
-The ``w^\star(\lambda)`` be the second component of ``f^{-1}``: ``(\lambda, w^\star(\lambda)) = f^{-1}(\lambda, 0)``.
-The Jacobian ``\partial w^\star(\lambda)`` is the derivative of the second component of ``f^{-1}`` with respect to its first input so it is the block 21 in the Jacobian
+Let ``w^\star(\lambda)`` be the second component of ``f^{-1}(\lambda, 0)``: ``(\lambda, w^\star(\lambda)) = f^{-1}(\lambda, 0)``.
+The Jacobian ``\partial w^\star(\lambda)`` is the derivative of the second component of ``f^{-1}(\lambda, 0)`` with respect to its first input so it is the block 21 in the Jacobian
 ```math
 \partial f^{-1}(\lambda, 0) = \begin{bmatrix}
    \sim & \sim\\
@@ -445,8 +445,9 @@ By the inverse function theorem
 ```
 We can then use the following result:
    
-> [**Schur complement**](https://en.wikipedia.org/wiki/Schur_complement): If ``A`` is an invertible matrix then for any matrices ``B, C, D`` of compatible dimension:
+> [**Schur complement**](https://en.wikipedia.org/wiki/Schur_complement): If ``A`` is an invertible matrix then for any matrices ``M, B, C, D`` of compatible dimensions:
 > ```math
+> M^{-1} =
 > \begin{bmatrix}
 > A & B\\
 > C & D
@@ -455,9 +456,9 @@ We can then use the following result:
 > -(M/A)^{-1}CA^{-1} & \sim
 > \end{bmatrix}
 > ```
-> where the *Schur complement* of the block ``A`` is ``M/A = D - CA^{-1}B``.
+> where the *Schur complement* of the block ``A``, denoted by ``M/A``, is ``M/A=D - CA^{-1}B``.
 
-In our case the Schur complement of the block ``I`` is ``\partial f(\lambda, w)/I = \partial_2 F(w, \lambda)``, this means that
+In our case the Schur complement of the block ``I`` is ``\partial f(\lambda, w)/I = \partial_1 F(w, \lambda)``, this means that
 ```math
 \partial w^\star(\lambda) = -\partial_1 F(w, \lambda)^{-1}\partial_2 F(w, \lambda).
 ```

--- a/Lectures/transformers.jl
+++ b/Lectures/transformers.jl
@@ -37,7 +37,7 @@ Given a sequence of ``n_\text{ctx}`` past vectors ``x_{-1}, \ldots, x_{-n_\text{
 
 * **Model** : Probability of next vector ``\hat{p}(x_0 | X)`` where ``X`` concatenates ``x_{-1}, \ldots, x_{-n_\text{ctx}}``.
 * **Loss** : Cross-entropy : ``\mathcal{L}_{\hat{p}}(X) \triangleq H(p, \hat{p}) = -\textbf{E}_p[\log(\hat{p})] = -\sum_{x_0} p(x_0 | X) \log(\hat{p}(x_0 | X))``
-* Particular case for ``\hat{p}(x_0 | X) = \delta_y`` : ``\mathcal{L}_{\hat{p}}(X) = -\log(\hat{p}(y | X))``
+* Particular case for ``p(x_0 | X) = \delta_y`` : ``\mathcal{L}_{\hat{p}}(X) = -\log(\hat{p}(y | X))``
 
 #### What about Language Models ?
 

--- a/Lectures/transformers.jl
+++ b/Lectures/transformers.jl
@@ -255,7 +255,7 @@ md"""
 ```
 """,
 md"""
-Mask prevent ``\hat{p}`` to look input the future:
+Mask prevents ``\hat{p}`` to look inputs in the future:
 ```math
 M
 =

--- a/Lectures/transformers.jl
+++ b/Lectures/transformers.jl
@@ -255,7 +255,7 @@ md"""
 ```
 """,
 md"""
-Mask prevents ``\hat{p}`` to look inputs in the future:
+Mask prevents ``\hat{p}`` to look at inputs in the future:
 ```math
 M
 =


### PR DESCRIPTION
- Fix typos and clarify maths (`implicit.jl`)
- Fix typo in proba notation in autoregressive models (`transformer.jl`) 